### PR TITLE
[.NET 5] Start adding some project capabilities

### DIFF
--- a/msbuild/dotnet5/targets/Xamarin.Shared.Sdk.targets
+++ b/msbuild/dotnet5/targets/Xamarin.Shared.Sdk.targets
@@ -116,6 +116,12 @@
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Xamarin.Shared.Sdk.DefaultItems.targets" />
 
+  <!-- Automatically supply project capabilities for IDE use -->
+  <ItemGroup>
+    <ProjectCapability Include="Apple" />
+    <ProjectCapability Include="Mobile" />
+  </ItemGroup>
+	
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <!-- Project types and how do we distinguish between them


### PR DESCRIPTION
Aligned with XA too, see https://github.com/xamarin/xamarin-android/pull/4383.

We'll start using Apple instead of iOS for these things at the IDE level since many 
behaviors don't actually depend on iOS but also apply to tvOS, watchOS, and so on.

These capabilities go before other imports just in case additional packages/targets 
from the SDK need to access them too.